### PR TITLE
moved println to after error evaluation on open file. If an error occurs...

### DIFF
--- a/thatswhyyoualwaysleaveanote.go
+++ b/thatswhyyoualwaysleaveanote.go
@@ -137,11 +137,11 @@ func SetStdoutThreshold(level Level) {
 // Will only append to this file
 func SetLogFile(path string) {
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0666)
-	fmt.Println("Logging to", file.Name())
 	if err != nil {
 		CRITICAL.Println("Failed to open log file:", path, err)
 		os.Exit(-1)
 	}
+        fmt.Println("Logging to", file.Name())
 
 	LogHandle = file
 	initialize()


### PR DESCRIPTION
..., the filename may not exist causing a panic. Check error first, then print status message fixes this.
