### PR TITLE
Added Log Flag set API

### DIFF
--- a/jww_test.go
+++ b/jww_test.go
@@ -6,52 +6,51 @@
 package jwalterweatherman
 
 import (
-	"bytes"
-	"github.com/stretchr/testify/assert"
-	"testing"
+    "bytes"
+    "github.com/stretchr/testify/assert"
+    "testing"
 )
 
 func TestLevels(t *testing.T) {
-	SetStdoutThreshold(LevelError)
-	assert.Equal(t, StdoutThreshold(), LevelError)
-	SetLogThreshold(LevelCritical)
-	assert.Equal(t, LogThreshold(), LevelCritical)
-	assert.NotEqual(t, StdoutThreshold(), LevelCritical)
-	SetStdoutThreshold(LevelWarn)
-	assert.Equal(t, StdoutThreshold(), LevelWarn)
+    SetStdoutThreshold(LevelError)
+    assert.Equal(t, StdoutThreshold(), LevelError)
+    SetLogThreshold(LevelCritical)
+    assert.Equal(t, LogThreshold(), LevelCritical)
+    assert.NotEqual(t, StdoutThreshold(), LevelCritical)
+    SetStdoutThreshold(LevelWarn)
+    assert.Equal(t, StdoutThreshold(), LevelWarn)
 }
 
 func TestDefaultLogging(t *testing.T) {
-	outputBuf := new(bytes.Buffer)
-	logBuf := new(bytes.Buffer)
-	LogHandle = logBuf
-	OutHandle = outputBuf
+    outputBuf := new(bytes.Buffer)
+    logBuf := new(bytes.Buffer)
+    LogHandle = logBuf
+    OutHandle = outputBuf
 
-	SetLogThreshold(LevelWarn)
-	SetLogFlag(DATE | TIME | LFILE)
-	SetStdoutThreshold(LevelError)
+    SetLogThreshold(LevelWarn)
+    SetStdoutThreshold(LevelError)
 
-	FATAL.Println("fatal err")
-	CRITICAL.Println("critical err")
-	ERROR.Println("an error")
-	WARN.Println("a warning")
-	INFO.Println("information")
-	DEBUG.Println("debugging info")
-	TRACE.Println("trace")
+    FATAL.Println("fatal err")
+    CRITICAL.Println("critical err")
+    ERROR.Println("an error")
+    WARN.Println("a warning")
+    INFO.Println("information")
+    DEBUG.Println("debugging info")
+    TRACE.Println("trace")
 
-	assert.Contains(t, logBuf.String(), "fatal err")
-	assert.Contains(t, logBuf.String(), "critical err")
-	assert.Contains(t, logBuf.String(), "an error")
-	assert.Contains(t, logBuf.String(), "a warning")
-	assert.NotContains(t, logBuf.String(), "information")
-	assert.NotContains(t, logBuf.String(), "debugging info")
-	assert.NotContains(t, logBuf.String(), "trace")
+    assert.Contains(t, logBuf.String(), "fatal err")
+    assert.Contains(t, logBuf.String(), "critical err")
+    assert.Contains(t, logBuf.String(), "an error")
+    assert.Contains(t, logBuf.String(), "a warning")
+    assert.NotContains(t, logBuf.String(), "information")
+    assert.NotContains(t, logBuf.String(), "debugging info")
+    assert.NotContains(t, logBuf.String(), "trace")
 
-	assert.Contains(t, outputBuf.String(), "fatal err")
-	assert.Contains(t, outputBuf.String(), "critical err")
-	assert.Contains(t, outputBuf.String(), "an error")
-	assert.NotContains(t, outputBuf.String(), "a warning")
-	assert.NotContains(t, outputBuf.String(), "information")
-	assert.NotContains(t, outputBuf.String(), "debugging info")
-	assert.NotContains(t, outputBuf.String(), "trace")
+    assert.Contains(t, outputBuf.String(), "fatal err")
+    assert.Contains(t, outputBuf.String(), "critical err")
+    assert.Contains(t, outputBuf.String(), "an error")
+    assert.NotContains(t, outputBuf.String(), "a warning")
+    assert.NotContains(t, outputBuf.String(), "information")
+    assert.NotContains(t, outputBuf.String(), "debugging info")
+    assert.NotContains(t, outputBuf.String(), "trace")
 }

--- a/jww_test.go
+++ b/jww_test.go
@@ -6,51 +6,52 @@
 package jwalterweatherman
 
 import (
-    "bytes"
-    "github.com/stretchr/testify/assert"
-    "testing"
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestLevels(t *testing.T) {
-    SetStdoutThreshold(LevelError)
-    assert.Equal(t, StdoutThreshold(), LevelError)
-    SetLogThreshold(LevelCritical)
-    assert.Equal(t, LogThreshold(), LevelCritical)
-    assert.NotEqual(t, StdoutThreshold(), LevelCritical)
-    SetStdoutThreshold(LevelWarn)
-    assert.Equal(t, StdoutThreshold(), LevelWarn)
+	SetStdoutThreshold(LevelError)
+	assert.Equal(t, StdoutThreshold(), LevelError)
+	SetLogThreshold(LevelCritical)
+	assert.Equal(t, LogThreshold(), LevelCritical)
+	assert.NotEqual(t, StdoutThreshold(), LevelCritical)
+	SetStdoutThreshold(LevelWarn)
+	assert.Equal(t, StdoutThreshold(), LevelWarn)
 }
 
 func TestDefaultLogging(t *testing.T) {
-    outputBuf := new(bytes.Buffer)
-    logBuf := new(bytes.Buffer)
-    LogHandle = logBuf
-    OutHandle = outputBuf
+	outputBuf := new(bytes.Buffer)
+	logBuf := new(bytes.Buffer)
+	LogHandle = logBuf
+	OutHandle = outputBuf
 
-    SetLogThreshold(LevelWarn)
-    SetStdoutThreshold(LevelError)
+	SetLogThreshold(LevelWarn)
+	SetLogFlag(DATE | TIME | LFILE)
+	SetStdoutThreshold(LevelError)
 
-    FATAL.Println("fatal err")
-    CRITICAL.Println("critical err")
-    ERROR.Println("an error")
-    WARN.Println("a warning")
-    INFO.Println("information")
-    DEBUG.Println("debugging info")
-    TRACE.Println("trace")
+	FATAL.Println("fatal err")
+	CRITICAL.Println("critical err")
+	ERROR.Println("an error")
+	WARN.Println("a warning")
+	INFO.Println("information")
+	DEBUG.Println("debugging info")
+	TRACE.Println("trace")
 
-    assert.Contains(t, logBuf.String(), "fatal err")
-    assert.Contains(t, logBuf.String(), "critical err")
-    assert.Contains(t, logBuf.String(), "an error")
-    assert.Contains(t, logBuf.String(), "a warning")
-    assert.NotContains(t, logBuf.String(), "information")
-    assert.NotContains(t, logBuf.String(), "debugging info")
-    assert.NotContains(t, logBuf.String(), "trace")
+	assert.Contains(t, logBuf.String(), "fatal err")
+	assert.Contains(t, logBuf.String(), "critical err")
+	assert.Contains(t, logBuf.String(), "an error")
+	assert.Contains(t, logBuf.String(), "a warning")
+	assert.NotContains(t, logBuf.String(), "information")
+	assert.NotContains(t, logBuf.String(), "debugging info")
+	assert.NotContains(t, logBuf.String(), "trace")
 
-    assert.Contains(t, outputBuf.String(), "fatal err")
-    assert.Contains(t, outputBuf.String(), "critical err")
-    assert.Contains(t, outputBuf.String(), "an error")
-    assert.NotContains(t, outputBuf.String(), "a warning")
-    assert.NotContains(t, outputBuf.String(), "information")
-    assert.NotContains(t, outputBuf.String(), "debugging info")
-    assert.NotContains(t, outputBuf.String(), "trace")
+	assert.Contains(t, outputBuf.String(), "fatal err")
+	assert.Contains(t, outputBuf.String(), "critical err")
+	assert.Contains(t, outputBuf.String(), "an error")
+	assert.NotContains(t, outputBuf.String(), "a warning")
+	assert.NotContains(t, outputBuf.String(), "information")
+	assert.NotContains(t, outputBuf.String(), "debugging info")
+	assert.NotContains(t, outputBuf.String(), "trace")
 }

--- a/thatswhyyoualwaysleaveanote.go
+++ b/thatswhyyoualwaysleaveanote.go
@@ -65,6 +65,13 @@ var (
 	fatal           *NotePad = &NotePad{Level: LevelFatal, Handle: os.Stdout, Logger: &FATAL, Prefix: "FATAL: "}
 	logThreshold    Level    = DefaultLogThreshold
 	outputThreshold Level    = DefaultStdoutThreshold
+
+	DATE     = log.Ldate
+	TIME     = log.Ltime
+	SFILE    = log.Lshortfile
+	LFILE    = log.Llongfile
+	MSEC     = log.Lmicroseconds
+	logFlags = DATE | TIME | SFILE
 )
 
 func init() {
@@ -91,12 +98,17 @@ func initialize() {
 	}
 
 	for _, n := range NotePads {
-		*n.Logger = log.New(n.Handle, n.Prefix, log.Ldate)
+		*n.Logger = log.New(n.Handle, n.Prefix, logFlags)
 	}
 
 	LOG = log.New(LogHandle,
 		"LOG:   ",
-		log.Ldate|log.Ltime|log.Lshortfile)
+		logFlags)
+}
+
+// Set the log Flags (Available flag: DATE, TIME, SFILE, LFILE and MSEC)
+func SetLogFlag(flags int) {
+	logFlags = flags
 }
 
 // Level returns the current global log threshold.
@@ -141,7 +153,7 @@ func SetLogFile(path string) {
 		CRITICAL.Println("Failed to open log file:", path, err)
 		os.Exit(-1)
 	}
-        fmt.Println("Logging to", file.Name())
+	fmt.Println("Logging to", file.Name())
 
 	LogHandle = file
 	initialize()


### PR DESCRIPTION
The logging flag was fixed. Set it as default 
```
(log.Ldate|log.Ltime|log.Lshortfile)
```
So I have added an API to set the Flag as per requirement.
```
func SetLogFlag(flags int)
```
And added a abstraction over log flags:
```
DATE     = log.Ldate
TIME     = log.Ltime
SFILE    = log.Lshortfile
LFILE    = log.Llongfile
MSEC     = log.Lmicroseconds
```