### PR TITLE
Move internal output to INFO level

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ verbosity.
     }
 ```
 
+Note that JWW's own internal output uses log levels as well, so set the log
+level before making any other calls if you want to see what it's up to.
+
 ### Using a temp log file
 
 JWW conveniently creates a temporary file and sets the log Handle to

--- a/thatswhyyoualwaysleaveanote.go
+++ b/thatswhyyoualwaysleaveanote.go
@@ -141,7 +141,8 @@ func SetLogFile(path string) {
 		CRITICAL.Println("Failed to open log file:", path, err)
 		os.Exit(-1)
 	}
-        fmt.Println("Logging to", file.Name())
+
+	INFO.Println("Logging to", file.Name())
 
 	LogHandle = file
 	initialize()
@@ -154,7 +155,7 @@ func UseTempLogFile(prefix string) {
 		CRITICAL.Println(err)
 	}
 
-	fmt.Println("Logging to", file.Name())
+	INFO.Println("Logging to", file.Name())
 
 	LogHandle = file
 	initialize()


### PR DESCRIPTION
Prevent client applications from having to deal with text being forced
to their stdout by using INFO rather than fmt for output.

I wanted to prevent JWW from output text in my application, this seemed like the easiest way. The other idea I had was a SilenceInternalOutput() method which would disable any fmt.Println() calls, while not breaking any existing applications which might enjoy the fact that they were getting "Logging to file ..." messages in their stdout. Would be happy to rework to that if preferred.