### PR TITLE
Add a LogListener option to Notepad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+*.bench
+go.sum

--- a/default_notepad.go
+++ b/default_notepad.go
@@ -76,6 +76,13 @@ func SetFlags(flags int) {
 	reloadDefaultNotepad()
 }
 
+// SetLogListeners configures the default logger with one or more log listeners.
+func SetLogListeners(l ...LogListener) {
+	defaultNotepad.logListeners = l
+	defaultNotepad.init()
+	reloadDefaultNotepad()
+}
+
 // Level returns the current global log threshold.
 func LogThreshold() Threshold {
 	return defaultNotepad.logThreshold
@@ -94,20 +101,4 @@ func GetLogThreshold() Threshold {
 // GetStdoutThreshold returns the Treshold for the stdout logger.
 func GetStdoutThreshold() Threshold {
 	return defaultNotepad.GetStdoutThreshold()
-}
-
-// LogCountForLevel returns the number of log invocations for a given threshold.
-func LogCountForLevel(l Threshold) uint64 {
-	return defaultNotepad.LogCountForLevel(l)
-}
-
-// LogCountForLevelsGreaterThanorEqualTo returns the number of log invocations
-// greater than or equal to a given threshold.
-func LogCountForLevelsGreaterThanorEqualTo(threshold Threshold) uint64 {
-	return defaultNotepad.LogCountForLevelsGreaterThanorEqualTo(threshold)
-}
-
-// ResetLogCounters resets the invocation counters for all levels.
-func ResetLogCounters() {
-	defaultNotepad.ResetLogCounters()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,7 @@
 module github.com/spf13/jwalterweatherman
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.2.2
+)

--- a/log_counter.go
+++ b/log_counter.go
@@ -6,50 +6,41 @@
 package jwalterweatherman
 
 import (
+	"io"
 	"sync/atomic"
 )
 
-type logCounter struct {
-	counter uint64
+// Counter is an io.Writer that increments a counter on Write.
+type Counter struct {
+	count uint64
 }
 
-func (c *logCounter) incr() {
-	atomic.AddUint64(&c.counter, 1)
+func (c *Counter) incr() {
+	atomic.AddUint64(&c.count, 1)
 }
 
-func (c *logCounter) resetCounter() {
-	atomic.StoreUint64(&c.counter, 0)
+// Reset resets the counter.
+func (c *Counter) Reset() {
+	atomic.StoreUint64(&c.count, 0)
 }
 
-func (c *logCounter) getCount() uint64 {
-	return atomic.LoadUint64(&c.counter)
+// Count returns the current count.
+func (c *Counter) Count() uint64 {
+	return atomic.LoadUint64(&c.count)
 }
 
-func (c *logCounter) Write(p []byte) (n int, err error) {
+func (c *Counter) Write(p []byte) (n int, err error) {
 	c.incr()
 	return len(p), nil
 }
 
-// LogCountForLevel returns the number of log invocations for a given threshold.
-func (n *Notepad) LogCountForLevel(l Threshold) uint64 {
-	return n.logCounters[l].getCount()
-}
-
-// LogCountForLevelsGreaterThanorEqualTo returns the number of log invocations
-// greater than or equal to a given threshold.
-func (n *Notepad) LogCountForLevelsGreaterThanorEqualTo(threshold Threshold) uint64 {
-	var cnt uint64
-
-	for i := int(threshold); i < len(n.logCounters); i++ {
-		cnt += n.LogCountForLevel(Threshold(i))
-	}
-
-	return cnt
-}
-
-// ResetLogCounters resets the invocation counters for all levels.
-func (n *Notepad) ResetLogCounters() {
-	for _, np := range n.logCounters {
-		np.resetCounter()
+// LogCounter creates a LogListener that counts log statements >= the given threshold.
+func LogCounter(counter *Counter, t1 Threshold) LogListener {
+	return func(t2 Threshold) io.Writer {
+		if t2 < t1 {
+			// Not interested in this threshold.
+			return nil
+		}
+		return counter
 	}
 }


### PR DESCRIPTION
For clients using the "log counting" feature, this will be slightly breaking. But it adds lots of flexibility which should make it worth while.

Now you can supply one or more `LogListener` funcs when creating a new `Notepad`. Typical use cases would be to capture ERROR logs in unit tests, and to count log statements. A listener for log counting is provided, see the `LogCounter` func.

If you want to add listeners to the global logger, see `SetLogListeners`.