### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/default_notepad.go
+++ b/default_notepad.go
@@ -100,7 +100,7 @@ func StdoutThreshold() Threshold {
 	return defaultNotepad.stdoutThreshold
 }
 
-// GetStdoutThreshold returns the defined Treshold for the log logger.
+// GetLogThreshold returns the defined Treshold for the log logger.
 func GetLogThreshold() Threshold {
 	return defaultNotepad.GetLogThreshold()
 }

--- a/notepad.go
+++ b/notepad.go
@@ -161,7 +161,7 @@ func (n *Notepad) SetLogOutput(handle io.Writer) {
 	n.init()
 }
 
-// GetStdoutThreshold returns the defined Treshold for the log logger.
+// GetLogThreshold returns the defined Treshold for the log logger.
 func (n *Notepad) GetLogThreshold() Threshold {
 	return n.logThreshold
 }


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?