### PR TITLE
add colored output

### DIFF
--- a/default_notepad.go
+++ b/default_notepad.go
@@ -41,7 +41,7 @@ func reloadDefaultNotepad() {
 }
 
 func init() {
-	defaultNotepad = NewNotepad(LevelError, LevelWarn, os.Stdout, ioutil.Discard, "", log.Ldate|log.Ltime)
+	defaultNotepad = NewNotepad(LevelError, LevelWarn, os.Stdout, ioutil.Discard, "", log.Ldate|log.Ltime, false)
 	reloadDefaultNotepad()
 }
 
@@ -80,6 +80,13 @@ func SetPrefix(prefix string) {
 // SetFlags set the flags for the default logger. "log.Ldate | log.Ltime" by default.
 func SetFlags(flags int) {
 	defaultNotepad.SetFlags(flags)
+	reloadDefaultNotepad()
+}
+
+// UseColor enabled or disables colored output.
+func UseColor() {
+	defaultNotepad.UseColor()
+	defaultNotepad.init()
 	reloadDefaultNotepad()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,10 @@
 module github.com/spf13/jwalterweatherman
 
+go 1.16
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.10.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/spf13/jwalterweatherman
 
-go 1.16
-
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.10.0

--- a/notepad.go
+++ b/notepad.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+
+	"github.com/fatih/color"
 )
 
 type Threshold int
@@ -28,14 +30,23 @@ const (
 	LevelFatal
 )
 
+var (
+	debugColor    = color.New(color.FgHiBlack)
+	infoColor     = color.New(color.FgHiBlue)
+	warnColor     = color.New(color.FgHiYellow)
+	errorColor    = color.New(color.FgRed)
+	criticalColor = color.New(color.FgRed, color.Bold)
+	fatalColor    = color.New(color.BgHiRed, color.FgWhite, color.Bold)
+)
+
 var prefixes map[Threshold]string = map[Threshold]string{
-	LevelTrace:    "TRACE",
-	LevelDebug:    "DEBUG",
-	LevelInfo:     "INFO",
-	LevelWarn:     "WARN",
-	LevelError:    "ERROR",
-	LevelCritical: "CRITICAL",
-	LevelFatal:    "FATAL",
+	LevelTrace:    "[TRACE]",
+	LevelDebug:    fmt.Sprintf("[%s]", debugColor.Sprint("DEBUG")),
+	LevelInfo:     fmt.Sprintf("[%s]", infoColor.Sprint("INFO")),
+	LevelWarn:     fmt.Sprintf("[%s]", warnColor.Sprint("WARN")),
+	LevelError:    fmt.Sprintf("[%s]", errorColor.Sprint("ERROR")),
+	LevelCritical: fmt.Sprintf("[%s]", criticalColor.Sprint("CRITICAL")),
+	LevelFatal:    fmt.Sprintf("[%s]", fatalColor.Sprint("FATAL")),
 }
 
 // Notepad is where you leave a note!

--- a/notepad.go
+++ b/notepad.go
@@ -20,6 +20,10 @@ func (t Threshold) String() string {
 	return prefixes[t]
 }
 
+func (t Threshold) ColoredString() string {
+	return coloredPrefixes[t]
+}
+
 const (
 	LevelTrace Threshold = iota
 	LevelDebug
@@ -30,23 +34,33 @@ const (
 	LevelFatal
 )
 
+var prefixes map[Threshold]string = map[Threshold]string{
+	LevelTrace:    "TRACE",
+	LevelDebug:    "DEBUG",
+	LevelInfo:     "INFO",
+	LevelWarn:     "WARN",
+	LevelError:    "ERROR",
+	LevelCritical: "CRITICAL",
+	LevelFatal:    "FATAL",
+}
+
 var (
-	debugColor    = color.New(color.FgHiBlack)
-	infoColor     = color.New(color.FgHiBlue)
-	warnColor     = color.New(color.FgHiYellow)
-	errorColor    = color.New(color.FgRed)
-	criticalColor = color.New(color.FgRed, color.Bold)
-	fatalColor    = color.New(color.BgHiRed, color.FgWhite, color.Bold)
+	DebugColor    = color.New(color.FgHiBlack)
+	InfoColor     = color.New(color.FgHiBlue)
+	WarnColor     = color.New(color.FgHiYellow)
+	ErrorColor    = color.New(color.FgRed)
+	CriticalColor = color.New(color.FgRed, color.Bold)
+	FatalColor    = color.New(color.FgHiRed, color.Italic, color.Bold)
 )
 
-var prefixes map[Threshold]string = map[Threshold]string{
+var coloredPrefixes map[Threshold]string = map[Threshold]string{
 	LevelTrace:    "[TRACE]",
-	LevelDebug:    fmt.Sprintf("[%s]", debugColor.Sprint("DEBUG")),
-	LevelInfo:     fmt.Sprintf("[%s]", infoColor.Sprint("INFO")),
-	LevelWarn:     fmt.Sprintf("[%s]", warnColor.Sprint("WARN")),
-	LevelError:    fmt.Sprintf("[%s]", errorColor.Sprint("ERROR")),
-	LevelCritical: fmt.Sprintf("[%s]", criticalColor.Sprint("CRITICAL")),
-	LevelFatal:    fmt.Sprintf("[%s]", fatalColor.Sprint("FATAL")),
+	LevelDebug:    fmt.Sprintf("[%s]", DebugColor.Sprint("DEBUG")),
+	LevelInfo:     fmt.Sprintf("[%s]", InfoColor.Sprint("INFO")),
+	LevelWarn:     fmt.Sprintf("[%s]", WarnColor.Sprint("WARN")),
+	LevelError:    fmt.Sprintf("[%s]", ErrorColor.Sprint("ERROR")),
+	LevelCritical: fmt.Sprintf("[%s]", CriticalColor.Sprint("CRITICAL")),
+	LevelFatal:    fmt.Sprintf("[%s]", FatalColor.Sprint("FATAL")),
 }
 
 // Notepad is where you leave a note!
@@ -69,6 +83,7 @@ type Notepad struct {
 	stdoutThreshold Threshold
 	prefix          string
 	flags           int
+	colored         bool
 
 	logListeners []LogListener
 }
@@ -87,7 +102,7 @@ func NewNotepad(
 	outThreshold Threshold,
 	logThreshold Threshold,
 	outHandle, logHandle io.Writer,
-	prefix string, flags int,
+	prefix string, flags int, color bool,
 	logListeners ...LogListener,
 ) *Notepad {
 
@@ -98,6 +113,7 @@ func NewNotepad(
 	n.logHandle = logHandle
 	n.stdoutThreshold = outThreshold
 	n.logThreshold = logThreshold
+	n.colored = color
 
 	if len(prefix) != 0 {
 		n.prefix = "[" + prefix + "] "
@@ -122,7 +138,12 @@ func (n *Notepad) init() {
 
 	for t, logger := range n.loggers {
 		threshold := Threshold(t)
-		prefix := n.prefix + threshold.String() + " "
+		prefix := ""
+		if n.colored {
+			prefix = n.prefix + threshold.ColoredString() + " "
+		} else {
+			prefix = n.prefix + threshold.String() + " "
+		}
 
 		switch {
 		case threshold >= n.logThreshold && threshold >= n.stdoutThreshold:
@@ -205,6 +226,11 @@ func (n *Notepad) SetPrefix(prefix string) {
 func (n *Notepad) SetFlags(flags int) {
 	n.flags = flags
 	n.init()
+}
+
+// UseColor enabled or disables colored output.
+func (n *Notepad) UseColor() {
+	n.colored = true
 }
 
 // Feedback writes plainly to the outHandle while

--- a/notepad_test.go
+++ b/notepad_test.go
@@ -19,7 +19,7 @@ func TestNotepad(t *testing.T) {
 
 	errorCounter := &Counter{}
 
-	n := NewNotepad(LevelCritical, LevelError, &outHandle, &logHandle, "TestNotePad", 0, LogCounter(errorCounter, LevelError))
+	n := NewNotepad(LevelCritical, LevelError, &outHandle, &logHandle, "TestNotePad", 0, false, LogCounter(errorCounter, LevelError))
 
 	require.Equal(t, LevelCritical, n.GetStdoutThreshold())
 	require.Equal(t, LevelError, n.GetLogThreshold())
@@ -59,7 +59,7 @@ func TestNotepadLogListener(t *testing.T) {
 		return &infoBuff
 	}
 
-	n := NewNotepad(LevelCritical, LevelError, ioutil.Discard, ioutil.Discard, "TestNotePad", 0, infoCapture, errorCapture)
+	n := NewNotepad(LevelCritical, LevelError, ioutil.Discard, ioutil.Discard, "TestNotePad", 0, false, infoCapture, errorCapture)
 
 	n.DEBUG.Println("Some debug")
 	n.INFO.Println("Some info")
@@ -84,7 +84,7 @@ func TestThresholdString(t *testing.T) {
 
 func BenchmarkLogPrintOnlyToCounter(b *testing.B) {
 	var logHandle, outHandle bytes.Buffer
-	n := NewNotepad(LevelCritical, LevelCritical, &outHandle, &logHandle, "TestNotePad", 0)
+	n := NewNotepad(LevelCritical, LevelCritical, &outHandle, &logHandle, "TestNotePad", 0, false)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Adds colored output to stdout. Doesn't support file-loggers atm (you'll get this `[[90mDEBUG[0m] debug.go:16: DEBUG`, I don't know how to use the old prefixes when writing to a file)

Exposes a method `notepad.UseColor()`, `UseColor()` and a parameter in `NewNotepad`.

With colors:

![Screen Shot 2021-05-04 at 23 55 41](https://user-images.githubusercontent.com/13184132/117074878-3ee48380-ad34-11eb-847e-3482c5eb4aaa.png)

Also exposes the colors so people can use them in their messages, if they wish. (`jww.DebugColor.Println("color")`)
