### PR TITLE
Fix typo for GetLogThreshold comment

### DIFF
--- a/notepad.go
+++ b/notepad.go
@@ -161,7 +161,7 @@ func (n *Notepad) SetLogOutput(handle io.Writer) {
 	n.init()
 }
 
-// GetStdoutThreshold returns the defined Treshold for the log logger.
+// GetLogThreshold returns the defined Treshold for the log logger.
 func (n *Notepad) GetLogThreshold() Threshold {
 	return n.logThreshold
 }


### PR DESCRIPTION
😄 Apologies for the nitpick lol. Thank you for the logging interface.

I saw this typo while trying to understand the difference between `outThreshold` and `logThreshold`.  Is there more info on that somewhere?

I work on a project that uses Viper and Logrus. I am going to swap out Logrus for JWW. Logrus is overkill for what we are doing, and I would like to avoid the extra dependency.